### PR TITLE
Fix #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 This ``acts_as`` extension provides the capability for having a default object.
 The class that has this specified needs to have a default column defined as an integer,
 string or boolean on the mapped database table.
+There is also optional support for each record to have a default object of another model.
 
 ## Install
 
@@ -22,6 +23,8 @@ In your Gemfile
 Currently is tested on rails3.2, ruby 1.9.3 and mysql
 
 ## Example
+
+### Default object
 
 ```ruby
   class Country < ActiveRecord::Base
@@ -40,12 +43,63 @@ Currently is tested on rails3.2, ruby 1.9.3 and mysql
 
 If no options provided `default` column is assumed.
 
+### Default object for each record
+
+```ruby
+  class User < ActiveRecord::Base
+    acts_as_defaultable :default, relation: :post
+  end
+
+  class Post < ActiveRecord::Base
+    after_destroy User.new
+  end
+
+  class Comment < ActiveRecord::Base
+  end
+
+  user = User.new
+  post = Post.create
+  user.default_post = post
+  user.save
+  user.default_post == post # => true
+
+  post.destroy
+  user.reload
+  user.default_post == nil # => true
+
+  user.default_post = Comment.create
+  user.default_post == nil # => true
+```
+
+Only an object of the relation class will be accepted.
+The `after_destroy` callback is optional but will ensure that results stay consistent in the event
+that a newly created **post** gets the same id as the one destroyed
+
 ## Notes
 
 The option to acts_as_defaultable is the `column` of the Model that defines default
 behaviour. This column can be a string, a boolean or an integer with default
 positive values 'on', true, 1 and default negative values 'off', false, 0 respectively.
 
+The column name for a default relation is `default_column` _ `relation_column` and can be either a string or an integer.
+
+Examples:
+
+```
+  class User < ActiveRecord::Base
+    acts_as_defaultable :default, relation: :post
+  end
+```
+
+Column name in users table must be `default_post`
+
+```
+  class User < ActiveRecord::Base
+    acts_as_defaultable :unique, relation: :post
+  end
+```
+
+Column name must be `unique_post`
 
 ## License
 

--- a/acts_as_defaultable.gemspec
+++ b/acts_as_defaultable.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'activesupport', ['>= 3.0.0']
   s.add_dependency 'activerecord',  ['>= 3.0.0']
 
-  s.add_development_dependency 'mysql2'
+  s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rails', ['= 3.2.16']
   s.add_development_dependency "rspec"
   s.add_development_dependency "rspec-rails"

--- a/lib/acts_as_defaultable.rb
+++ b/lib/acts_as_defaultable.rb
@@ -8,12 +8,24 @@ module ActsAsDefaultable
 
       after_save :set_unique_default
 
-      column = options.first
+      if options.size > 1
+        column = options.first
+        relation = options.second[:relation]
+      elsif options.first.is_a?(Hash)
+        relation = options.first[:relation]
+      else
+        column = options.first
+      end
+
       column ||= :default
       column = column.to_s
-
+      relation = relation.to_s
+      relation_column = column + '_' + relation
 
       puts "acts_as_defaultable: Specify a column #{column} in #{self}" unless column_names.include?(column)
+      if !relation.blank? && !column_names.include?(relation_column)
+         puts "acts_as_defaultable: Specify a column #{relation_column} in #{self}"
+      end
 
       if column_names.include?(column)
         positive_value =
@@ -40,6 +52,10 @@ module ActsAsDefaultable
       class_methods = %(
         def self.default_column
           "#{column}"
+        end
+
+        def self.default_relation_column
+          "#{relation_column}"
         end
 
         def self.default_positive_value
@@ -69,6 +85,19 @@ module ActsAsDefaultable
               obj.update_attribute self.class.default_column, self.class.default_negative_value
             end
           end
+        end
+
+        def #{relation_column}
+         Object.const_get("#{relation.classify}").find_by_id(read_attribute(self.class.default_relation_column))
+        end
+
+        def #{relation_column}=(obj)
+         default_relation_id = obj.instance_of?(#{relation.classify}) ? obj.id : 0
+         write_attribute(self.class.default_relation_column, default_relation_id)
+        end
+
+        def after_destroy(record)
+          self.class.where(self.class.default_relation_column => record.id).update_all(self.class.default_relation_column => 0)
         end
 
       EOF

--- a/lib/acts_as_defaultable.rb
+++ b/lib/acts_as_defaultable.rb
@@ -8,14 +8,16 @@ module ActsAsDefaultable
 
       after_save :set_unique_default
 
-      column    = options.first.to_sym unless options.blank?
-      column  ||= :default
+      column = options.first
+      column ||= :default
+      column = column.to_s
 
-      puts "acts_as_defaultable: Specify a column #{column} in #{self.to_s}" unless self.column_names.include?(column.to_s)
 
-      if self.column_names.include?(column.to_s)
+      puts "acts_as_defaultable: Specify a column #{column} in #{self}" unless column_names.include?(column)
+
+      if column_names.include?(column)
         positive_value =
-          case self.columns_hash[column.to_s].type
+          case columns_hash[column].type
           when :integer
             1
           when :boolean
@@ -25,7 +27,7 @@ module ActsAsDefaultable
           end
 
         negative_value =
-          case self.columns_hash[column.to_s].type
+          case columns_hash[column].type
           when :integer
             0
           when :boolean
@@ -37,7 +39,7 @@ module ActsAsDefaultable
 
       class_methods = %(
         def self.default_column
-          "#{column.to_sym}"
+          "#{column}"
         end
 
         def self.default_positive_value
@@ -54,11 +56,11 @@ module ActsAsDefaultable
         #{class_methods}
 
         def self.default
-          self.all_defaults.first
+          all_defaults.first
         end
 
         def self.all_defaults
-          where(self.default_column.to_sym => self.default_positive_value)
+          where(default_column => default_positive_value)
         end
 
         def set_unique_default

--- a/spec/dummy/app/models/admin.rb
+++ b/spec/dummy/app/models/admin.rb
@@ -1,0 +1,4 @@
+class Admin < ActiveRecord::Base
+  acts_as_defaultable :main, relation: :blog_post
+end
+

--- a/spec/dummy/app/models/blog_post.rb
+++ b/spec/dummy/app/models/blog_post.rb
@@ -1,0 +1,4 @@
+class BlogPost < ActiveRecord::Base
+  after_destroy User.new, Admin.new
+end
+

--- a/spec/dummy/app/models/fail_one.rb
+++ b/spec/dummy/app/models/fail_one.rb
@@ -1,3 +1,3 @@
 class FailOne < ActiveRecord::Base
-  acts_as_defaultable :epic
+  acts_as_defaultable :epic, relation: :blog_posts
 end

--- a/spec/dummy/app/models/user.rb
+++ b/spec/dummy/app/models/user.rb
@@ -1,0 +1,4 @@
+class User < ActiveRecord::Base
+  acts_as_defaultable relation: :blog_post
+end
+

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,42 +1,13 @@
-# MySQL.  Versions 4.1 and 5.0 are recommended.
-# 
-# Install the MYSQL driver
-#   gem install mysql2
-#
-# Ensure the MySQL gem is defined in your Gemfile
-#   gem 'mysql2'
-#
-# And be sure to use new-style password hashing:
-#   http://dev.mysql.com/doc/refman/5.0/en/old-client.html
+default: &default
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+
 development:
-  adapter: mysql2
-  encoding: utf8
-  reconnect: false
-  database: dummy_development
-  pool: 5
-  username: root
-  password:
-  socket: /var/run/mysqld/mysqld.sock
+  <<: *default
+  database: db/development.sqlite3
 
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
-  adapter: mysql2
-  encoding: utf8
-  reconnect: false
-  database: dummy_test
-  pool: 5
-  username: root
-  password:
-  socket: /var/run/mysqld/mysqld.sock
+  <<: *default
+  database: db/test.sqlite3
 
-production:
-  adapter: mysql2
-  encoding: utf8
-  reconnect: false
-  database: dummy_production
-  pool: 5
-  username: root
-  password:
-  socket: /var/run/mysqld/mysqld.sock

--- a/spec/dummy/db/migrate/20150522153654_create_users.rb
+++ b/spec/dummy/db/migrate/20150522153654_create_users.rb
@@ -1,0 +1,10 @@
+class CreateUsers < ActiveRecord::Migration
+  def change
+    create_table :users do |t|
+      t.string :name
+      t.boolean :default
+      t.integer :default_blog_post
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20150522155643_create_blog_posts.rb
+++ b/spec/dummy/db/migrate/20150522155643_create_blog_posts.rb
@@ -1,0 +1,9 @@
+class CreateBlogPosts < ActiveRecord::Migration
+  def change
+    create_table :blog_posts do |t|
+      t.string :text
+      t.timestamps
+    end
+  end
+end
+

--- a/spec/dummy/db/migrate/20150522160050_create_admins.rb
+++ b/spec/dummy/db/migrate/20150522160050_create_admins.rb
@@ -1,0 +1,11 @@
+class CreateAdmins < ActiveRecord::Migration
+  def change
+    create_table :admins do |t|
+      t.string :name
+      t.boolean :main
+      t.string :main_blog_post
+      t.timestamps
+    end
+  end
+end
+

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -34,13 +34,6 @@ ActiveRecord::Schema.define(:version => 20120105110842) do
     t.datetime "updated_at", :null => false
   end
 
-  create_table "posts", :force => true do |t|
-    t.string   "name"
-    t.integer  "user_id"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
   create_table "string_defaults", :force => true do |t|
     t.string   "name"
     t.string   "default"
@@ -53,20 +46,6 @@ ActiveRecord::Schema.define(:version => 20120105110842) do
     t.boolean  "default",    :default => false
     t.datetime "created_at",                    :null => false
     t.datetime "updated_at",                    :null => false
-  end
-
-  create_table "users", :force => true do |t|
-    t.string   "role"
-    t.string   "name"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
-  create_table "without_cancans", :force => true do |t|
-    t.string   "name"
-    t.integer  "position"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
   end
 
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,11 +11,25 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120105110842) do
+ActiveRecord::Schema.define(:version => 20150522160050) do
+
+  create_table "admins", :force => true do |t|
+    t.string   "name"
+    t.boolean  "main"
+    t.string   "main_blog_post"
+    t.datetime "created_at",     :null => false
+    t.datetime "updated_at",     :null => false
+  end
 
   create_table "anothers", :force => true do |t|
     t.string   "test"
     t.integer  "unique"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
+  create_table "blog_posts", :force => true do |t|
+    t.string   "text"
     t.datetime "created_at", :null => false
     t.datetime "updated_at", :null => false
   end
@@ -46,6 +60,14 @@ ActiveRecord::Schema.define(:version => 20120105110842) do
     t.boolean  "default",    :default => false
     t.datetime "created_at",                    :null => false
     t.datetime "updated_at",                    :null => false
+  end
+
+  create_table "users", :force => true do |t|
+    t.string   "name"
+    t.boolean  "default"
+    t.integer  "default_blog_post"
+    t.datetime "created_at",        :null => false
+    t.datetime "updated_at",        :null => false
   end
 
 end

--- a/spec/factories/admin.rb
+++ b/spec/factories/admin.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :admin do
+    name 'bill'
+  end
+
+  factory :admin2, class: Admin do
+    name 'chief'
+  end
+end

--- a/spec/factories/blog_post.rb
+++ b/spec/factories/blog_post.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :blogPost do
+    text 'hello'
+  end
+
+  factory :blogPost2, class: BlogPost do
+    text 'world'
+  end
+end
+

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :user do
+    name 'bill'
+  end
+
+  factory :user2, class: User do
+    name 'chief'
+  end
+end
+

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe Admin do
+
+  let(:admin1) { FactoryGirl.create(:admin) }
+  let(:admin2) { FactoryGirl.create(:admin2) }
+  let(:post1) { FactoryGirl.create(:blogPost) }
+  let(:post2) { FactoryGirl.build(:blogPost2) }
+  let(:other) { FactoryGirl.create(:other) }
+
+  it 'should have a default relation column definition' do
+    Admin.respond_to?('default_relation_column').should be true
+  end
+
+  it 'should return the argument as the default relation column' do
+    Admin.default_relation_column.should be_eql('main_blog_post')
+  end
+
+  it 'should have an attribute named main_blog_post' do
+    admin1.has_attribute?('main_blog_post').should be true
+  end
+
+  it 'should return nil if there is no default relation object' do
+    admin1.main_blog_post.should be_nil
+  end
+
+  it 'should return the default relation object' do
+    admin1.main_blog_post = post1
+    admin1.save
+    admin1.main_blog_post.should be_eql(post1)
+  end
+
+  it 'should return nil if relation object is deleted' do
+    admin1.main_blog_post = post1
+    admin1.save
+    post1.destroy
+    admin1.reload
+    admin1.main_blog_post.should be_nil
+  end
+
+  it "should return nil if relation object is deleted and another one take it's place" do
+    admin1.main_blog_post = post1
+    admin1.save
+    id = post1.id
+    post1.destroy
+
+    post2.id = id
+    post2.save
+    admin1.reload
+    admin1.reload.main_blog_post.should be_nil
+  end
+
+  it 'both users should return nil if relation object is deleted' do
+    admin1.main_blog_post = post1
+    admin2.main_blog_post = post1
+
+    id = post1.id
+    post1.destroy
+    post2.id = id
+    post2.save
+    admin1.reload
+    admin2.reload
+
+    admin1.main_blog_post.should be_nil
+    admin2.main_blog_post.should be_nil
+  end
+
+  it 'should return nil if relation object is not saved' do
+    admin1.main_blog_post = post2
+    admin1.main_blog_post.should be_nil
+  end
+
+  it 'should return nil if wrong relation object class is saved' do
+    admin1.main_blog_post = other
+    admin1.main_blog_post.should be_nil
+  end
+
+end
+

--- a/spec/models/another_spec.rb
+++ b/spec/models/another_spec.rb
@@ -6,11 +6,11 @@ describe Another do
   let(:other) { FactoryGirl.build(:other) }
 
   it 'should have a class method named default' do
-    Another.respond_to?('default').should be_true
+    Another.respond_to?('default').should be true
   end
 
   it 'should have a default column definition' do
-    Another.respond_to?('default_column').should be_true
+    Another.respond_to?('default_column').should be true
   end
 
   it 'should return the argument as the default column' do

--- a/spec/models/boolean_default_spec.rb
+++ b/spec/models/boolean_default_spec.rb
@@ -6,11 +6,11 @@ describe BooleanDefault do
   let(:two) { FactoryGirl.build(:true_boolean_default) }
 
   it 'should have a class method named default' do
-    BooleanDefault.respond_to?('default').should be_true
+    BooleanDefault.respond_to?('default').should be true
   end
 
   it 'should have a default column definition' do
-    BooleanDefault.respond_to?('default_column').should be_true
+    BooleanDefault.respond_to?('default_column').should be true
   end
 
   it 'should return the argument as the default column' do

--- a/spec/models/string_default_spec.rb
+++ b/spec/models/string_default_spec.rb
@@ -6,11 +6,11 @@ describe StringDefault do
   let(:two) { FactoryGirl.build(:true_string_default) }
 
   it 'should have a class method named default' do
-    StringDefault.respond_to?('default').should be_true
+    StringDefault.respond_to?('default').should be true
   end
 
   it 'should have a default column definition' do
-    StringDefault.respond_to?('default_column').should be_true
+    StringDefault.respond_to?('default_column').should be true
   end
 
   it 'should return the argument as the default column' do

--- a/spec/models/test_default_spec.rb
+++ b/spec/models/test_default_spec.rb
@@ -6,11 +6,11 @@ describe TestDefault do
   let(:two) { FactoryGirl.build(:td_two) }
 
   it 'should have a class method named default' do
-    TestDefault.respond_to?('default').should be_true
+    TestDefault.respond_to?('default').should be true
   end
 
   it 'should have a default column definition' do
-    TestDefault.respond_to?('default_column').should be_true
+    TestDefault.respond_to?('default_column').should be true
   end
 
   it 'should return the argument as the default column' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper'
+
+describe User do
+
+  let(:user1) { FactoryGirl.create(:user) }
+  let(:user2) { FactoryGirl.create(:user2) }
+  let(:post1) { FactoryGirl.create(:blogPost) }
+  let(:post2) { FactoryGirl.build(:blogPost2) }
+  let(:other) { FactoryGirl.create(:other) }
+
+  it 'should have a default relation column definition' do
+    User.respond_to?('default_relation_column').should be true
+  end
+
+  it 'should return the argument as the default relation column' do
+    User.default_relation_column.should be_eql('default_blog_post')
+  end
+
+  it 'should have an attribute named default_blog_post' do
+    user1.has_attribute?('default_blog_post').should be true
+  end
+
+  it 'should return nil if there is no default relation object' do
+    user1.default_blog_post.should be_nil
+  end
+
+  it 'should return the default relation object' do
+    user1.default_blog_post = post1
+    user1.save
+    user1.default_blog_post.should be_eql(post1)
+  end
+
+  it 'should return nil if relation object is deleted' do
+    user1.default_blog_post = post1
+    user1.save
+    post1.destroy
+    user1.reload
+    user1.default_blog_post.should be_nil
+  end
+
+  it "should return nil if relation object is deleted and another one take it's place" do
+    user1.default_blog_post = post1
+    user1.save
+    id = post1.id
+    post1.destroy
+
+    post2.id = id
+    post2.save
+    user1.reload
+    user1.reload.default_blog_post.should be_nil
+  end
+
+  it 'both users should return nil if relation object is deleted' do
+    user1.default_blog_post = post1
+    user2.default_blog_post = post1
+
+    id = post1.id
+    post1.destroy
+    post2.id = id
+    post2.save
+    user1.reload
+    user2.reload
+    user1.default_blog_post.should be_nil
+    user2.default_blog_post.should be_nil
+  end
+
+  it 'should return nil if relation object is not saved' do
+    user1.default_blog_post = post2
+    user1.default_blog_post.should be_nil
+  end
+
+  it 'should return nil if wrong relation object class is saved' do
+    user1.default_blog_post = other
+    user1.default_blog_post.should be_nil
+  end
+
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,6 @@ Spork.prefork do
   require File.expand_path("../dummy/config/environment", __FILE__)
 
   require 'rspec/rails'
-  require 'rspec/autorun'
 
   # Requires supporting ruby files with custom matchers and macros, etc,
   # in spec/support/ and its subdirectories.
@@ -72,6 +71,7 @@ Spork.prefork do
 
     # Include factory_girl's helpers
     #config.include FactoryGirl::Syntax::Methods
+    config.expect_with(:rspec) { |c| c.syntax = :should }
   end
 end
 


### PR DESCRIPTION
Hello.
This series of patches cleanup the project a bit as well as implementing the feature requested in #1.
The first patch changes the database adapter to **sqlite**, since mysql is a pretty harsh test/development requirement in my opinion. Also removes some unused/leftover table definitions from schema.rb

The second patch fixes rspec tests not running with newer versions of **rspec** since gemspec does not have an upper version limit. Also fixes some deprecation warnings.

Third patch just removes some superfluous `self` references and `to_s` & `to_sym` calls.

The rest patches implement the feature. I don't particularly like the code that handles the `acts_as_defaultable` arguments, but i couldn't think of something cleaner.
I couldn't use ruby's 2.x.x keyword arguments and i didn't want to break compatibility. (optional first argument and not in a hash form)

Active Records getters & setters for the relation attribute are overridden with care taken to call `read_attribute` and `write_attribute` (that Active Record would call) inside them.

The `after_destroy` callback must be manually added to the model since i think the extra cost on delete operations should be a conscious choice. (record id's are autoincremented by default so someone could get a away without the callback)
